### PR TITLE
Fix truncated/invalid bearer token exceptions

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -400,7 +400,7 @@ GrantManager.prototype.validateToken = function(token) {
     return;
   }
   
-  if ( token.signed == undefined ) {
+  if ( token.signed === undefined ) {
     return;
   }
 

--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -399,6 +399,10 @@ GrantManager.prototype.validateToken = function(token) {
   if ( token.content.iat < this.notBefore ) {
     return;
   }
+  
+  if ( token.signed == undefined ) {
+    return;
+  }
 
   var verify = crypto.createVerify('RSA-SHA256');
   verify.update( token.signed );


### PR DESCRIPTION
Using a very short/truncated bearer token causes an exception in verify.update() instead of a more graceful access denial message. This commit fixes this.