### PR TITLE
Full https support

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export VERSION="1.9.3.Final"
+export VERSION="1.9.4.Final"
 export KEYCLOAK="keycloak-${VERSION}"


### PR DESCRIPTION
This PR addresses Issue #2, and bumps the test server to the most recent keycloak (1.9.4). Tests for HTTPS currently do not exist. I am working locally on a way to automate the installation and configuration of an HTTPS enabled keycloak for the travis-ci builds, but in the interest of expediency, I thought you might like to have the code changes first.