### PR TITLE
Make start_server.sh sleep a bit to see if that helps CI.

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -20,6 +20,8 @@ function waitForServer {
     fi
     sleep 1
   done
+  # See if this helps travis-ci not fail the first test
+  sleep 5
 }
 
 ARCHIVE="${KEYCLOAK}.tar.gz"


### PR DESCRIPTION
Not sure if this will help CI, but it's worth a shot. When we see the CI job failing, we see it only on the first test. I suspect there is a race condition, and the tests are starting before the server is fully ready. So, sleep more. But who knows... just throwing spaghetti at the wall and seeing what sticks since I can't recreate these failures locally.