### PR TITLE
Short circuit token validation if it's unsigned.

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -316,7 +316,7 @@ GrantManager.prototype.validateGrant = function validateGrant (grant) {
  * @return {Token} The same token passed in, or `undefined`
  */
 GrantManager.prototype.validateToken = function validateToken (token) {
-  if (!token || token.isExpired() || token.content.iat < this.notBefore) return;
+  if (!token || token.isExpired() || !token.signed || token.content.iat < this.notBefore) return;
   const verify = crypto.createVerify('RSA-SHA256');
   verify.update(token.signed);
   if (!verify.verify(this.publicKey, token.signature, 'base64')) return;

--- a/test/unit/grant-manager-test.js
+++ b/test/unit/grant-manager-test.js
@@ -33,3 +33,29 @@ test('GrantManager#obtainDirectly should work with https', (t) => {
     .then((grant) => t.equal(grant.access_token.token, 'Dummy access token'))
     .then(t.end);
 });
+
+test('GrantManager#validateToken returns undefined for an invalid token', (t) => {
+  const expiredToken = {
+    isExpired: () => true
+  };
+  const unsignedToken = {
+    isExpired: () => false,
+    signed: undefined
+  };
+  const notBeforeToken = {
+    isExpired: () => false,
+    signed: true,
+    content: { iat: -1 }
+  };
+  const manager = getManager('test/fixtures/keycloak-https.json');
+  const tokens = [
+    undefined,
+    expiredToken,
+    unsignedToken,
+    notBeforeToken
+  ];
+  for (const token of tokens) {
+    t.equal(manager.validateToken(token), undefined);
+  }
+  t.end();
+});


### PR DESCRIPTION
This commit addresses https://github.com/keycloak/keycloak-nodejs-auth-utils/pull/9/ and adds
unit testing for the `GrantManager#validateToken` method.