### PR TITLE
Fixed wrong JWT token structure with expiration property

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -40,7 +40,7 @@ function Token (token, clientId) {
       this.signed = parts[0] + '.' + parts[1];
     } catch (err) {
       this.content = {
-        expiresAt: 0
+        exp: 0
       };
     }
   }


### PR DESCRIPTION
JWT structure typically uses `exp` instead of `expiresAt`.

This caused the `isExpired()` method to fail for invalid token formats. (e.g. `Bearer 1234`).
If you update the project with this change you also should assure to use the new version in 

https://github.com/keycloak/keycloak-nodejs-connect

**UPDATE**

I think this all relates to https://github.com/keycloak/keycloak-nodejs-auth-utils/issues/15
This PR does not fix the cause ... just a quick-win but maybe it also makes sense.

Cheers
Orlando