### PR TITLE
Don't always require clientId in hasRole

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -58,14 +58,12 @@ Token.prototype.isExpired = function isExpired () {
 /**
  * Determine if this token has an associated role.
  *
- * This method is only functional if the token is constructed
- * with a `clientId` parameter.
- *
  * The parameter matches a role specification using the following rules:
  *
  * - If the name contains no colons, then the name is taken as the entire
  *   name of a role within the current application, as specified via
- *   `clientId`.
+ *   `clientId`. This method is only functional if the token is constructed
+ *   with a `clientId` parameter.
  * - If the name starts with the literal `realm:`, the subsequent portion
  *   is taken as the name of a _realm-level_ role.
  * - Otherwise, the name is split at the colon, with the first portion being
@@ -77,12 +75,8 @@ Token.prototype.isExpired = function isExpired () {
  * @return {boolean} `true` if this token has the specified role, otherwise `false`.
  */
 Token.prototype.hasRole = function hasRole (name) {
-  if (!this.clientId) {
-    return false;
-  }
-
   const parts = name.split(':');
-  if (parts.length === 1) {
+  if (parts.length === 1 && this.clientId) {
     return this.hasApplicationRole(this.clientId, parts[0]);
   }
 


### PR DESCRIPTION
Token.hasRole should not require the clientId if the realm/application have explicitly been set, as the clientId is not always available (I wonder when this is actually the case, seems like never for me...).

Note: Additionally, if `parts.length === 1` the given rule could also be interpreted as realmRole and be checked via `return this.hasRealmRole(parts[0])`:
```
const parts = name.split(':');
if (parts.length === 1) {
	if (this.clientId && this.hasApplicationRole(this.clientId, parts[0])) {
		return true;
	} else {
		return this.hasRealmRole(parts[0]);
	}
} else {
	if (parts[0] === 'realm') {
		return this.hasRealmRole(parts[1]);
	} else {
		return this.hasApplicationRole(parts[0], parts[1]);
	}
}
```