### PR TITLE
Added `token-minimum-time-to-live` config option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -106,6 +106,15 @@ Config.prototype.configure = function configure (config) {
    * @type {String} */
   this.realmAdminUrl = this.authServerUrl + '/admin/realms/' + this.realm;
 
+  /**
+   * Amount of time, in seconds, to preemptively refresh an active access token with the Keycloak server 
+   * before it expires. This is especially useful when the access token is sent to another REST client 
+   * where it could expire before being evaluated. This value should never exceed the realm’s access token lifespan. 
+   * This is OPTIONAL. The default value is 0 seconds, so adapter will refresh access token just if it’s expired.
+   * @type {Number}
+   * */
+  this.tokenTTL = config['token-minimum-time-to-live'] || 0;
+
   const plainKey = config['realm-public-key'];
 
   /**

--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -38,6 +38,7 @@ function GrantManager (config) {
   this.publicKey = config.publicKey;
   this.public = config.public;
   this.notBefore = 0;
+  this.tokenTTL = config.tokenTTL;
 }
 
 /**
@@ -118,7 +119,7 @@ GrantManager.prototype.obtainFromCode = function obtainFromCode (request, code, 
  * @param {Function} callback Optional callback if promises are not used.
  */
 GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callback) {
-  if (!grant.isExpired()) {
+  if (!grant.isExpired() && !grant.willTokenExpireBeforeTimeToLive(this.tokenTTL)) {
     return nodeify(Promise.resolve(grant), callback);
   }
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -81,4 +81,21 @@ Grant.prototype.isExpired = function isExpired () {
   return this.access_token.isExpired();
 };
 
+/**
+ * Determine if this grant will expire before the token's time to live is up.
+ *
+ * Determination is made based upon the expiration status of the `access_token`.
+ *
+ * An expired grant *may* be possible to refresh, if a valid
+ * `refresh_token` is available.
+ *
+ * @return {boolean} `true` if will expire, otherwise `false`.
+ */
+Grant.prototype.willTokenExpireBeforeTimeToLive = function willTokenExpireBeforeTimeToLive(ttl) {
+  if (!this.access_token) {
+    return true;
+  }
+  return this.access_token.willTokenExpireBeforeTimeToLive(ttl);
+};
+
 module.exports = Grant;

--- a/lib/token.js
+++ b/lib/token.js
@@ -56,6 +56,15 @@ Token.prototype.isExpired = function isExpired () {
 };
 
 /**
+ * Determine if this token is will expire before the end of its TTL.
+ *
+ * @return {boolean} `true` if it will expire, otherwise `false`.
+ */
+Token.prototype.willTokenExpireBeforeTimeToLive = function willTokenExpireBeforeTimeToLive(ttl) {
+  return ((this.content.exp * 1000) + ttl < Date.now());
+}
+
+/**
  * Determine if this token has an associated role.
  *
  * This method is only functional if the token is constructed


### PR DESCRIPTION
Amount of time, in seconds, to preemptively refresh an active access
token with the Keycloak server before it expires.