### PR TITLE
KEYCLOAK-3419 Add support for env variable references in Config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ after_script:
    - ./scripts/stop-server.sh
 notifications:
   irc: "chat.freenode.net#brass-monkey"
-
+env:
+  global:
+    - USER: ci

--- a/test/unit/config-test.js
+++ b/test/unit/config-test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Config = require('../../index').Config;
+
+const test = require('tape');
+
+const publicKey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgH1MnB3XC7vCXYYZZVth0fHgfOMnJmpaldkX+WMi+U9ivkYkEo+uRL6QNmysbbFtllb/btGOMSPyTpQ+6WBsTPgL3BuWJiA4Xvg0FkkTvZb/B/Uta4SAOtM8/qB9Aq/papgK2eCwB6t803RyPThLrzOV8q1q+KocRl5BhAoN97mQyTytesSMrgsWwpyyXSqejIefaIlefucVzK7seZghEApofzJBz9ryiqOcAATD4oC6uzmUUKvXHeYsIT6DnlZdYIm4Bf884QXYGD9NhvjMrDWqs1kTNOjFoGvxmvcKXx05lztYDMii8jv1pKYNEVmNuUOL4TW5IRd5dtOVvrpd1QIDAQAB';
+
+test('Config#configure', (t) => {
+  let cfg = new Config({'realm': 'test-realm', 'realm-public-key': publicKey});
+
+  t.equal(cfg.realm, 'test-realm');
+  t.end();
+});
+
+test('Config#configure with boolean', (t) => {
+  let cfg = new Config({'public': true, 'realm-public-key': publicKey});
+
+  t.equal(cfg.public, true);
+  t.end();
+});
+
+test('Config#configure with env variable reference not set', (t) => {
+  let cfg = new Config({'realm': '${env.NOT_SET}', 'realm-public-key': publicKey});
+
+  t.equal(cfg.realm, '');
+  t.end();
+});
+
+test('Config#configure with env variable reference not set with fallback', (t) => {
+  let cfg = new Config({'realm': '${env.NOT_SET:fallback}', 'realm-public-key': publicKey});
+
+  t.equal(cfg.realm, 'fallback');
+  t.end();
+});
+
+test('Config#configure with env variable reference set', (t) => {
+  let cfg = new Config({'realm': '${env.USER}', 'realm-public-key': publicKey});
+
+  t.equal(cfg.realm, process.env.USER);
+  t.end();
+});
+
+test('Config#configure with env variable reference set with fallback', (t) => {
+  let cfg = new Config({'realm': '${env.USER:fallback}', 'realm-public-key': publicKey});
+
+  t.equal(cfg.realm, process.env.USER);
+  t.end();
+});


### PR DESCRIPTION
Users can now refer to environment variables via ${env.MY_ENV_VAR}.
Optionally users can specify default values that should be returned
if the environment variable is not. E.g. ${env.NOT_SET:fallback}
will yield 'fallback' in case the environment variable 'NOT_SET'
is not configured.

This allows for generic configuration files.

Signed-off-by: Thomas Darimont <thomas.darimont@gmail.com>