### PR TITLE
Display a warning message if public key is missing

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -143,9 +143,14 @@ Config.prototype.configure = function configure (config) {
    */
   this.publicKey = '-----BEGIN PUBLIC KEY-----\n';
 
-  for (let i = 0; i < plainKey.length; i = i + 64) {
-    this.publicKey += plainKey.substring(i, i + 64);
-    this.publicKey += '\n';
+  if (plainKey) {
+      for (let i = 0; i < plainKey.length; i = i + 64) {
+          this.publicKey += plainKey.substring(i, i + 64);
+          this.publicKey += '\n';
+      }
+  } else {
+    console.warn('Please configure your keycloak.json file properly. Attribute realm-public-key is missing.\nAborting!');
+    process.exit()
   }
 
   this.publicKey += '-----END PUBLIC KEY-----\n';


### PR DESCRIPTION
@sebastienblanc @stianst this change prevents people from getting Node.js exceptions when the public key is missing. This is just an alternative until we benefit of what @sebastienblanc has been doing here https://issues.jboss.org/browse/KEYCLOAK-3871 