### PR TITLE
update the repo name in the package.json for proper link on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/keycloak/keycloak-auth-utils.git"
+    "url": "http://github.com/keycloak/keycloak-nodejs-auth-utils.git"
   },
   "bugs": "https://issues.jboss.org/browse/KEYCLOAK"
 }


### PR DESCRIPTION
I noticed that the link from npm's site to this git repo was wrong, thus getting a 404 for the repo, 

https://www.npmjs.com/package/keycloak-auth-utils