### PR TITLE
Remove console.log calls

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -131,7 +131,6 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
     grant_type: 'refresh_token',
     refresh_token: grant.refresh_token.token
   };
-  console.log(params.refresh_token);
   const handler = refreshHandler(this, grant);
   const options = postOptions(this);
 

--- a/lib/rotation.js
+++ b/lib/rotation.js
@@ -37,7 +37,6 @@ Rotation.prototype.retrieveJWKs = function retrieveJWKs (callback) {
   const url = this.realmUrl + '/protocol/openid-connect/certs';
   const options = URL.parse(url);
   options.method = 'GET';
-  console.log(url);
   const promise = new Promise((resolve, reject) => {
     const req = getProtocol(options).request(options, (response) => {
       if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -47,7 +46,6 @@ Rotation.prototype.retrieveJWKs = function retrieveJWKs (callback) {
       response.on('data', (d) => (json += d.toString()));
       response.on('end', () => {
         const data = JSON.parse(json);
-        console.log(data);
         if (data.error) reject(data);
         else resolve(data);
       });
@@ -69,7 +67,6 @@ Rotation.prototype.getJWK = function getJWK (kid) {
 
     // check if we are allowed to send request
   var currentTime = new Date().getTime() / 1000;
-  console.log(this.minTimeBetweenJwksRequests);
   if (currentTime > this.lastTimeRequesTime + this.minTimeBetweenJwksRequests) {
     return this.retrieveJWKs()
         .then(publicKeys => {


### PR DESCRIPTION
There are a few calls to `console.log`, presumably added during debugging when key rotation was introduced.

It didn't contain information which would be useful under normal circumstances (or any context to explain what the log entry was about), so I've removed them.