### PR TITLE
For invalid realm keys, resolving the promise with an undefined token

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -287,7 +287,7 @@ GrantManager.prototype.validateToken = function validateToken (token) {
     try {
       verify.update(token.signed);
       if (!verify.verify(this.publicKey, token.signature, 'base64')) {
-        return Promise.reject();
+        return Promise.resolve();
       }
     } catch (err) {
       console.error('Misconfigured parameters. Check your keycloak.json file!', err);


### PR DESCRIPTION
When a user has an invalid realm key, the token correctly fails verification (verify.verify)
but then in the validateGrant method the rejection throws the error and then the chain
continues. The user is granted access. By resolving the promise with an undefined token,
the user will be denied access with the 403 expected.

Tests can be written with the expected 403 in the keycloak-nodejs-connect code base.