### PR TITLE
Bad promise return type in utils funcs validateToken and validateGrant

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -127,6 +127,10 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
     return nodeify(Promise.reject(new Error('Unable to refresh without a refresh token')), callback);
   }
 
+  if (grant.refresh_token.isExpired()) {
+    return nodeify(Promise.reject(new Error('Unable to refresh with expired refresh token')), callback);
+  }
+
   const params = {
     grant_type: 'refresh_token',
     refresh_token: grant.refresh_token.token
@@ -257,9 +261,9 @@ GrantManager.prototype.validateGrant = function validateGrant (grant, callback) 
   })
   .then(token => {
     grant.id_token = token;
-    return grant;
-  }, () => { console.log('validate id token went wrong'); })
-  .catch(() => { return Promise.reject(); });
+    return Promise.resolve(grant);
+  }, () => { console.log('validate id token went wrong'); return Promise.resolve(grant); })
+  .catch(() => { console.log('reject validateGrant'); return Promise.reject(); });
   return nodeify(promise, callback);
 };
 
@@ -303,7 +307,7 @@ GrantManager.prototype.validateToken = function validateToken (token) {
       if (!verify.verify(key, token.signature)) {
         return Promise.reject();
       }
-      return token;
+      return Promise.resolve(token);
     });
 };
 


### PR DESCRIPTION
KEYCLOAK-4768
validateToken: return promise instead of token.
validateGrants: return promise in promise chain. in case of error reject.
ensureFreshness: check refresh token is not expired.

Thanks