### PR TITLE
Add method to obtain service account grant in GrantManager

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -102,6 +102,25 @@ GrantManager.prototype.obtainFromCode = function obtainFromCode (request, code, 
 };
 
 /**
+ * Obtain a service account grant.
+ * Client option 'Service Accounts Enabled' needs to be on.
+ *
+ * This method returns or promise or may optionally take a callback function.
+ *
+ * @param {Function} callback Optional callback, if not using promises.
+ */
+GrantManager.prototype.obtainFromClientCredentials = function obtainFromlientCredentials (callback) {
+  const params = {
+    grant_type: 'client_credentials',
+    client_id: this.clientId
+  };
+  const handler = createHandler(this);
+  const options = postOptions(this);
+
+  return nodeify(fetch(this, handler, options, params), callback);
+};
+
+/**
  * Ensure that a grant is *fresh*, refreshing if required & possible.
  *
  * If the access_token is not expired, the grant is left untouched.

--- a/test/integration/grant-manager-spec.js
+++ b/test/integration/grant-manager-spec.js
@@ -117,6 +117,16 @@ test('GrantManager in confidential mode should be able to validate an invalid to
     .then(t.end);
 });
 
+test('GrantManager in confidential mode should be able to obtain a service account grant', (t) => {
+  manager.obtainFromClientCredentials()
+    .then(delay(3000))
+    .then((grant) => {
+      return manager.validateAccessToken(grant.access_token.token);
+    })
+    .then((result) => t.equal(result, false))
+    .then(t.end);
+});
+
 test('GrantManager should be able to validate tokens in a grant', (t) => {
   let originalAccessToken, originalRefreshToken, orginalIdToken;
   manager.obtainDirectly('test-user', 'tiger')


### PR DESCRIPTION
KEYCLOAK-4767
New method in order to get a grant for a service account using client
credentials. Request will use 'client_credentials' as the grant type.

Thanks