### PR TITLE
add configuration property option realmPublicKey

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -151,7 +151,7 @@ Config.prototype.configure = function configure (config) {
     * Formatted public-key.
     * @type {String}
     */
-  const plainKey = resolveValue(config['realm-public-key']);
+  const plainKey = resolveValue(config['realm-public-key'] || config.realmPublicKey);
 
   if (plainKey) {
     this.publicKey = '-----BEGIN PUBLIC KEY-----\n';

--- a/package.json
+++ b/package.json
@@ -48,9 +48,11 @@
     "jshint": "^2.9.2",
     "nock": "^9.0.2",
     "nsp": "*",
+    "rsa-compat": "^1.2.7",
     "semistandard": "^9.2.1",
     "tap-spec": "^4.1.1",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "tape-catch": "^1.0.6"
   },
   "repository": {
     "type": "git",

--- a/test/unit/hconfig-test.js
+++ b/test/unit/hconfig-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const test = require('tape-catch');
+const RSA = require('rsa-compat').RSA;
 const Config = require('../../index').Config;
-
-const test = require('tape');
 
 test('Config#configure', (t) => {
   let cfg = new Config({'realm': 'test-realm'});
@@ -45,4 +45,26 @@ test('Config#configure with env variable reference set with fallback', (t) => {
 
   t.equal(cfg.realm, process.env.USER);
   t.end();
+});
+
+test('Config#configure with realm-public-key', (t) => {
+  t.plan(2);
+  RSA.generateKeypair(2048, 65537, { public: true, pem: true }, (err, keyz) => {
+    t.error(err, 'generated keypair successfully');
+    let plainKey = keyz.publicKeyPem.split(/\r?\n/).filter(item => item && !item.startsWith('---')).join('');
+    let cfg = new Config({ 'realm-public-key': plainKey });
+    t.equal(cfg.publicKey, keyz.publicKeyPem.replace(/\r/g, ''));
+    t.end();
+  });
+});
+
+test('Config#configure with realmPublicKey', (t) => {
+  t.plan(2);
+  RSA.generateKeypair(2048, 65537, { public: true, pem: true }, (err, keyz) => {
+    t.error(err, 'generated keypair successfully');
+    let plainKey = keyz.publicKeyPem.split(/\r?\n/).filter(item => item && !item.startsWith('---')).join('');
+    let cfg = new Config({ realmPublicKey: plainKey });
+    t.equal(cfg.publicKey, keyz.publicKeyPem.replace(/\r/g, ''));
+    t.end();
+  });
 });


### PR DESCRIPTION
In some environments it is desirable to configure a realms public key using a configuration object rather than the `keycloak.json` file. The realm key is the only configuration option that does not have a javascript property name.

```js
let kcConfig = {
  clientId: 'someapi',
  bearerOnly: true,
  serverUrl: 'http://localhost:8080/auth',
  realm: 'test-realm',
  realmPublicKey: 'MIIBIjANBgkqhkiG9w0BA ... IDAQAB'
};

let keycloak = new Keycloak({}, kcConfig);
```