### PR TITLE
fix missing callback for validateAccessToken (again)

### DIFF
--- a/lib/grant-manager.js
+++ b/lib/grant-manager.js
@@ -162,7 +162,7 @@ GrantManager.prototype.validateAccessToken = function validateAccessToken (token
   const options = postOptions(this, '/protocol/openid-connect/token/introspect');
   const handler = validationHandler(this, token);
 
-  return nodeify(fetch(this, handler, options, params));
+  return nodeify(fetch(this, handler, options, params), callback);
 };
 
 GrantManager.prototype.userInfo = function userInfo (token, callback) {

--- a/test/integration/grant-manager-spec.js
+++ b/test/integration/grant-manager-spec.js
@@ -151,6 +151,18 @@ test('GrantManager should be able to remove invalid tokens from a grant', (t) =>
     .then(t.end);
 });
 
+test('GrantManager should return empty access token data', (t) => {
+  manager.createGrant('{ }')
+    .then((grant) => {
+      t.equal(grant.access_token, undefined);
+      t.equal(grant.refresh_token, undefined);
+      t.equal(grant.id_token, undefined);
+      t.equal(grant.token_type, undefined);
+      t.equal(grant.expires_in, undefined);
+    })
+    .then(t.end);
+});
+
 test('GrantManager validate empty access token', (t) => {
   manager.validateAccessToken('')
     .then((result) => {
@@ -162,7 +174,6 @@ test('GrantManager validate empty access token', (t) => {
 test('GrantManager return user realm role', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
-      console.log(grant.access_token);
       t.true(grant.access_token.hasRealmRole('user'));
     })
     .then(t.end);
@@ -171,7 +182,6 @@ test('GrantManager return user realm role', (t) => {
 test('GrantManager validate non existent role', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
-      console.log(grant.access_token);
       t.false(grant.access_token.hasRealmRole(''));
     })
     .then(t.end);
@@ -180,7 +190,6 @@ test('GrantManager validate non existent role', (t) => {
 test('GrantManager validate non existent role app', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
-      console.log(grant.access_token);
       t.false(grant.access_token.hasRole(''));
     })
     .then(t.end);
@@ -189,20 +198,32 @@ test('GrantManager validate non existent role app', (t) => {
 test('GrantManager validate existent role app', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
-      console.log(grant.access_token);
       t.true(grant.access_token.hasRole('test'));
     })
     .then(t.end);
 });
 
-test('GrantManager should return empty access token data', (t) => {
-  manager.createGrant('{ }')
+test('GrantManager validate role app with empty clientId', (t) => {
+  manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
-      t.equal(grant.access_token, undefined);
-      t.equal(grant.refresh_token, undefined);
-      t.equal(grant.id_token, undefined);
-      t.equal(grant.token_type, undefined);
-      t.equal(grant.expires_in, undefined);
+      grant.access_token.clientId = '';
+      t.false(grant.access_token.hasRole('test'));
+    })
+    .then(t.end);
+});
+
+test('GrantManager validate empty role app', (t) => {
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      t.false(grant.access_token.hasApplicationRole('', ''));
+    })
+    .then(t.end);
+});
+
+test('GrantManager return user realm role based on realm name', (t) => {
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      t.true(grant.access_token.hasRole('realm:user'));
     })
     .then(t.end);
 });

--- a/test/integration/grant-manager-spec.js
+++ b/test/integration/grant-manager-spec.js
@@ -227,3 +227,16 @@ test('GrantManager return user realm role based on realm name', (t) => {
     })
     .then(t.end);
 });
+
+test('GrantManager in confidential mode should use callback if provided and validate access token', (t) => {
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      manager.validateAccessToken(grant.access_token, function (err, result) {
+        if (err) {
+          t.end(err);
+        }
+        t.equal(result, grant.access_token);
+        t.end();
+      });
+    });
+});


### PR DESCRIPTION
Somehow the fix from KEYCLOAK-3891 vanished in version 3.0.0-Final (and in master branch).

The callback should now be called correctly, if there is one provided.